### PR TITLE
Ensure tests pass with newline handling and CLI fixes

### DIFF
--- a/ai_code_platform/cli.py
+++ b/ai_code_platform/cli.py
@@ -8,9 +8,19 @@ current_dir = os.path.dirname(os.path.abspath(__file__))
 parent_dir = os.path.dirname(current_dir) # This should be the project root if cli.py is in ai_code_platform
 # This script (cli.py) is intended to be in the `ai_code_platform` directory.
 # Imports are relative to this location.
-from llm_code_generator.llm_service import LLMService, LLMConfigurationError, LLMAPIError
-from llm_code_generator.claude_service import ClaudeService
-from llm_code_generator.local_llm_service import LocalLLMService
+from ai_code_platform.llm_code_generator.llm_service import (
+    LLMService,
+    LLMConfigurationError,
+    LLMAPIError,
+)
+from ai_code_platform.llm_code_generator.claude_service import ClaudeService
+from ai_code_platform.llm_code_generator.local_llm_service import LocalLLMService
+
+# Capture default values at import time so that tests patching the service
+# classes don't replace these with mocks.
+CLAUDE_DEFAULT_MODEL = ClaudeService.DEFAULT_MODEL
+LOCAL_DEFAULT_API_BASE = LocalLLMService.DEFAULT_API_BASE
+LOCAL_DEFAULT_MODEL = LocalLLMService.DEFAULT_MODEL
 
 
 def main():
@@ -32,20 +42,23 @@ def main():
     parser.add_argument(
         "--claude-model",
         type=str,
-        default=ClaudeService.DEFAULT_MODEL,
-        help=f"Claude model to use (e.g., claude-3-opus-20240229, claude-3-haiku-20240307). Default: {ClaudeService.DEFAULT_MODEL}",
+        default=CLAUDE_DEFAULT_MODEL,
+        help=(
+            "Claude model to use (e.g., claude-3-opus-20240229, "
+            f"claude-3-haiku-20240307). Default: {CLAUDE_DEFAULT_MODEL}"
+        ),
     )
     parser.add_argument(
         "--local-url",
         type=str,
-        default=LocalLLMService.DEFAULT_API_BASE,
-        help=f"Base URL for the local LLM API. Default: {LocalLLMService.DEFAULT_API_BASE}",
+        default=LOCAL_DEFAULT_API_BASE,
+        help=f"Base URL for the local LLM API. Default: {LOCAL_DEFAULT_API_BASE}",
     )
     parser.add_argument(
         "--local-model",
         type=str,
-        default=LocalLLMService.DEFAULT_MODEL,
-        help=f"Model name for the local LLM. Default: {LocalLLMService.DEFAULT_MODEL}",
+        default=LOCAL_DEFAULT_MODEL,
+        help=f"Model name for the local LLM. Default: {LOCAL_DEFAULT_MODEL}",
     )
     parser.add_argument(
         "--api-key",

--- a/ai_code_platform/llm_code_generator/tests/test_claude_service.py
+++ b/ai_code_platform/llm_code_generator/tests/test_claude_service.py
@@ -119,11 +119,11 @@ def test_claude_service_generate_code_with_markdown_stripping(mock_anthropic_con
 
 
 @pytest.mark.parametrize("anthropic_exception_class, mock_args_tuple, expected_llm_error, error_message_detail", [
-    (APIConnectionError, ({"message": "Connection failed.", "request": MagicMock()}), LLMAPIError, "Claude API connection error"),
-    (RateLimitError, ({"message": "Rate limit.", "response": MagicMock(), "body": None}), LLMAPIError, "Claude API rate limit exceeded"),
-    (APIStatusError, ({"message": "Server Error.", "response": MagicMock(status_code=500), "body": None}), LLMAPIError, "Claude API status error (status 500)"),
-    (APIError, ({"message":"Some API error", "request": MagicMock()}), LLMAPIError, "An unexpected error occurred while calling Claude API"), # General Anthropic APIError
-    (Exception, (("Some other unexpected error",),), LLMAPIError, "An unexpected error occurred while calling Claude API") # General non-Anthropic exception
+    (APIConnectionError, ({"message": "Connection failed.", "request": MagicMock()},), LLMAPIError, "Claude API connection error"),
+    (RateLimitError, ({"message": "Rate limit.", "response": MagicMock(), "body": None},), LLMAPIError, "Claude API rate limit exceeded"),
+    (APIStatusError, ({"message": "Server Error.", "response": MagicMock(status_code=500), "body": None},), LLMAPIError, "Claude API status error (status 500)"),
+    (APIError, ({"message": "Some API error", "request": MagicMock(), "body": None},), LLMAPIError, "An unexpected error occurred while calling Claude API"),  # General Anthropic APIError
+    (Exception, (("Some other unexpected error",),), LLMAPIError, "An unexpected error occurred while calling Claude API")  # General non-Anthropic exception
 ])
 def test_claude_service_generate_code_api_errors(mock_anthropic_constructor, anthropic_exception_class, mock_args_tuple, expected_llm_error, error_message_detail):
     """Test various API errors during code generation."""


### PR DESCRIPTION
## Summary
- normalize newline handling in LLM services
- capture default models before patching in CLI and import correct modules
- adjust Claude service API error tests

## Testing
- `PYTHONPATH=$PWD/ai_code_platform:$PWD pytest ai_code_platform/llm_code_generator/tests`

------
https://chatgpt.com/codex/tasks/task_e_6858c19469d08332ba780de43ae9b0fb